### PR TITLE
3 Fixes

### DIFF
--- a/NewGenome.py
+++ b/NewGenome.py
@@ -199,7 +199,7 @@ class NewGenome(QtWidgets.QMainWindow):
             args += " " + '"' + GlobalSettings.appdir.replace("\\","/") + "CASPERinfo" + '"'
             args += " " + '"' + self.file.replace("\\","/") + '"'
 
-        args += " " + '"' + self.orgName.text() + '"'
+        args += " " + '"' + self.orgName.text() + " " + self.strainName.text() + '"'
         args += " " + '"' + "notes" + '"'
 
         name = self.orgCode.text() + "_" + str(self.Endos[self.comboBoxEndo.currentText()][0])
@@ -430,7 +430,6 @@ class NewGenome(QtWidgets.QMainWindow):
         # make sure that there are cspr files in the DB
         file_names = os.listdir(GlobalSettings.CSPR_DB)
         noCSPRFiles = True
-        noCSPRFiles = True
         for file in file_names:
             if 'cspr' in file:
                 noCSPRFiles = False
@@ -467,4 +466,6 @@ class NewGenome(QtWidgets.QMainWindow):
             GlobalSettings.mainWindow.orgChoice.clear()
             GlobalSettings.mainWindow.endoChoice.clear()
             GlobalSettings.mainWindow.getData()
+            GlobalSettings.MTWin.launch(GlobalSettings.CSPR_DB)
+            GlobalSettings.pop_Analysis.launch(GlobalSettings.CSPR_DB)
             self.hide()

--- a/ncbi.py
+++ b/ncbi.py
@@ -146,13 +146,16 @@ class NCBI_search_tool(QtWidgets.QWidget):
     def browseForFolder(self):
         # get the folder
         filed = QtWidgets.QFileDialog()
-        self.output_path = QtWidgets.QFileDialog.getExistingDirectory(filed, "Select a Directory",
-                                                       GlobalSettings.CSPR_DB, QtWidgets.QFileDialog.ShowDirsOnly)
-        if(os.path.isdir(self.output_path) == False):
-            return
 
-        # make sure to append the '/' to the folder path
-        self.output_directory.setText(self.output_path)
+        temp_path = QtWidgets.QFileDialog.getExistingDirectory(filed, "Select a Directory",
+                                                       GlobalSettings.CSPR_DB, QtWidgets.QFileDialog.ShowDirsOnly)
+
+        if temp_path != "" and os.path.isdir(self.output_path) == True:
+            self.output_path = temp_path
+
+            # make sure to append the '/' to the folder path
+            self.output_directory.setText(self.output_path)
+
 
     @QtCore.pyqtSlot()
     def query_db(self):
@@ -363,6 +366,7 @@ class NCBI_search_tool(QtWidgets.QWidget):
                 link = str(dir).replace('ftp://ftp.ncbi.nlm.nih.gov', '')
                 ftp.cwd(link)
                 dir_files = ftp.nlst()
+                print("output path: " + str(self.output_path))
                 # if(dir_files.count("GO_TO_CURRENT_VERSION") != 0):
                 #     print(dir_files)
                 for file in dir_files:
@@ -381,6 +385,7 @@ class NCBI_search_tool(QtWidgets.QWidget):
                             files.append(output_file)
                     if self.fna_checkbox.isChecked():
                         if file.find('genomic.fna') != -1 and file.find('_cds_') == -1 and file.find('_rna_') == -1:
+                            print(output_file)
                             with open(output_file, 'wb') as f:
                                 ftp.retrbinary(f"RETR {file}", f.write)
                             files.append(output_file)


### PR DESCRIPTION
- Updated New Genome to include strain (if provided) in the organism name that is passed to the seq finder .exe
- Fixed bug in NCBI tool where if the user selects the browse button to change directories, then clicks cancel, the saved directory is and empty string which causes the tool to crash once you try to download/save files from NCBI.
- Fixed issue where org/endo dropdowns weren't getting populated if the user started out in New Genome when starting the program.